### PR TITLE
Add thermodynamic columns at 298 K to kinetics dataset

### DIFF
--- a/data/kinetics/README.md
+++ b/data/kinetics/README.md
@@ -1,12 +1,19 @@
 # QuantumPioneer Kinetics Dataset
 
-| Column        | Type   | Units       | Description                                      |
-| ------------- | ------ | ----------- | ------------------------------------------------ |
-| **`rxn_smi`** | string | —           | Reaction SMILES (`r1.r2>>p1.p2`)                 |
-| **`k_298`**   | number | m³/(mol·s)  | Bimolecular rate coefficient at 298 K            |
-| **`A_low`**   | number | m³/(mol·s)  | Arrhenius pre-exponential factor, 300–1000 K     |
-| **`Ea_low`**  | number | kcal/mol    | Activation energy, 300–1000 K                    |
-| **`A_high`**  | number | m³/(mol·s)  | Arrhenius pre-exponential factor, 1000–2000 K    |
-| **`Ea_high`** | number | kcal/mol    | Activation energy, 1000–2000 K                   |
-| **`barrier`** | number | kcal/mol    | Forward barrier (ZPE-scaled DLPNO/DFT)           |
-| **`Hrxn`**    | number | kcal/mol    | Forward reaction enthalpy (ZPE-scaled DLPNO/DFT) |
+| Column             | Type   | Units       | Description                                        |
+| ------------------ | ------ | ----------- | -------------------------------------------------- |
+| **`rxn_smi`**      | string | —           | Reaction SMILES (`r1.r2>>p1.p2`)                   |
+| **`k_298`**        | number | m³/(mol·s)  | Bimolecular rate coefficient at 298 K              |
+| **`A_low`**        | number | m³/(mol·s)  | Arrhenius pre-exponential factor, 300–1000 K       |
+| **`Ea_low`**       | number | kcal/mol    | Activation energy, 300–1000 K                      |
+| **`A_high`**       | number | m³/(mol·s)  | Arrhenius pre-exponential factor, 1000–2000 K      |
+| **`Ea_high`**      | number | kcal/mol    | Activation energy, 1000–2000 K                     |
+| **`barrier`**      | number | kcal/mol    | Forward barrier (DLPNO + scaled DFT ZPE)           |
+| **`Hrxn`**         | number | kcal/mol    | Forward reaction enthalpy (DLPNO + scaled DFT ZPE) |
+| **`deltaHrxn298`** | number | kcal/mol    | Forward reaction enthalpy at 298 K                 |
+| **`deltaGrxn298`** | number | kcal/mol    | Forward reaction Gibbs energy at 298 K             |
+| **`P2M`**          | number | kcal/mol    | Petersson-to-Melius energy difference at 298 K     |
+
+The thermodynamic properties `deltaHrxn298` and `deltaGrxn298` are derived from calculations using
+Petersson-type bond additivity corrections (BACs). Add `P2M` to these to obtain their Melius-type
+BAC-corrected versions.

--- a/data/thermo/README.md
+++ b/data/thermo/README.md
@@ -18,7 +18,7 @@
 | **`H0`**                     | number | J/mol        | Wilhoit integration constant for enthalpy       |
 | **`S0`**                     | number | J/(mol·K)    | Wilhoit integration constant for entropy        |
 | **`B`**                      | number | K            | Wilhoit scaled temperature coefficient          |
-| **`DHPM`**                   | number | J/mol        | Petersson-to-Melius enthalpy difference         |
+| **`P2M`**                    | number | J/mol        | Petersson-to-Melius energy difference           |
 
 ## Transition States
 
@@ -37,12 +37,14 @@
 DLPNO-CCSD(T)-F12d single-point calculations
 
 - The standard enthalpy of formation (`H298`) and Wilhoit integration constant for enthalpy (`H0`)
-derive from calculations using Petersson-type bond additivity corrections (BACs). Add `DHPM` to
+derive from calculations using Petersson-type bond additivity corrections (BACs). Add `P2M` to
 either of these in order to obtain their Melius-type BAC-corrected versions.
 
 ## Wilhoit Model
 
-The Wilhoit model provides a physically meaningful representation of temperature-dependent heat capacity, guaranteeing correct limits at zero and infinite temperature. The model is defined by the following equations:
+The Wilhoit model provides a physically meaningful representation of temperature-dependent heat
+capacity, guaranteeing correct limits at zero and infinite temperature. The model is defined by
+the following equations:
 
 ### Heat Capacity
 
@@ -53,7 +55,8 @@ $$
 
 where $y \equiv T/(T + B)$ is a scaled temperature ranging from zero to one.
 
-$C_\mathrm{p}(0)$ is the heat capacity at zero temperature, whose value is equal to 33.2579 J/(mol·K) for all species in the dataset.
+$C_\mathrm{p}(0)$ is the heat capacity at zero temperature, whose value is equal to 33.2579 J/(mol·K)
+for all species in the dataset.
 
 ### Enthalpy
 

--- a/scripts/kinetics/collect_kinetic_data.ipynb
+++ b/scripts/kinetics/collect_kinetic_data.ipynb
@@ -8,9 +8,10 @@
       "outputs": [],
       "source": [
         "import pathlib\n",
-        "\n",
+        "import re\n",
         "from functools import lru_cache\n",
         "\n",
+        "import numpy as np\n",
         "import pandas as pd\n",
         "import swifter\n",
         "\n",
@@ -19,14 +20,14 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "id": "60549dfc",
       "metadata": {},
       "outputs": [],
       "source": [
         "cwd = pathlib.Path().absolute()\n",
         "QUANTUM_GREEN_DIR = pathlib.Path(\"/home/shared/projects/quantum_green\")\n",
-        "PAPER_DIR = QUANTUM_GREEN_DIR / \"paper\" / \"figure\" / \"section_3_2_3_rate\"\n",
+        "PAPER_DIR = QUANTUM_GREEN_DIR / \"paper\" / \"figure\"\n",
         "DATABASE_DIR = cwd.parent.parent / \"data\" / \"kinetics\""
       ]
     },
@@ -46,11 +47,26 @@
         "\n",
         "\n",
         "@lru_cache(maxsize=None)\n",
-        "def canonical_smiles(smiles):\n",
+        "def remapped_to_canonical(smiles):\n",
         "    mol = Chem.MolFromSmiles(smiles)\n",
         "    for atom in mol.GetAtoms():\n",
         "        atom.SetAtomMapNum(0)\n",
         "    return Chem.MolToSmiles(mol, isomericSmiles=True)\n",
+        "\n",
+        "\n",
+        "def remap_smiles(smiles):\n",
+        "    i = 0\n",
+        "\n",
+        "    def _replace(_):\n",
+        "        nonlocal i\n",
+        "        i += 1\n",
+        "        return f\":{i}\"\n",
+        "\n",
+        "    return re.sub(r\":\\d+\", _replace, smiles)\n",
+        "\n",
+        "\n",
+        "def canonical_smiles(smiles):\n",
+        "    return remapped_to_canonical(remap_smiles(smiles))\n",
         "\n",
         "\n",
         "def clean_rxn_smi(rxn_smi):\n",
@@ -421,7 +437,9 @@
       ],
       "source": [
         "rate_data = pd.read_csv(\n",
-        "    PAPER_DIR / \"quantum_green_ts_data_24september17_dft_opted_dlpno_sp_rates.csv\"\n",
+        "    PAPER_DIR\n",
+        "    / \"section_3_2_3_rate\"\n",
+        "    / \"quantum_green_ts_data_24september17_dft_opted_dlpno_sp_rates.csv\",\n",
         ")\n",
         "rate_data[\"rxn_smi\"] = rate_data.swifter.apply(get_rxn_smi, axis=1)\n",
         "head(rate_data)"
@@ -430,13 +448,266 @@
     {
       "cell_type": "code",
       "execution_count": 5,
-      "id": "77782139",
+      "id": "98dbb78f",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>species_dft_log_source_utf_8_sha512</th>\n",
+              "      <th>asmi</th>\n",
+              "      <th>multiplicity</th>\n",
+              "      <th>std_xyz_str</th>\n",
+              "      <th>species_dft_frequencies</th>\n",
+              "      <th>species_dft_hartreefock_energy_hartree</th>\n",
+              "      <th>species_dlpno_sp_hartree</th>\n",
+              "      <th>p_thermo</th>\n",
+              "      <th>m_thermo</th>\n",
+              "      <th>p_H298</th>\n",
+              "      <th>m_H298</th>\n",
+              "      <th>p_S298</th>\n",
+              "      <th>m_S298</th>\n",
+              "      <th>p_Cp300</th>\n",
+              "      <th>m_Cp300</th>\n",
+              "      <th>p_Cp400</th>\n",
+              "      <th>m_Cp400</th>\n",
+              "      <th>p_Cp500</th>\n",
+              "      <th>m_Cp500</th>\n",
+              "      <th>p_Cp600</th>\n",
+              "      <th>m_Cp600</th>\n",
+              "      <th>p_Cp800</th>\n",
+              "      <th>m_Cp800</th>\n",
+              "      <th>p_Cp1000</th>\n",
+              "      <th>m_Cp1000</th>\n",
+              "      <th>p_Cp1500</th>\n",
+              "      <th>m_Cp1500</th>\n",
+              "      <th>p_G298</th>\n",
+              "      <th>m_G298</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>42d67c486eb53d22486a5d1da768e644bf644469198894...</td>\n",
+              "      <td>[C:1]([C:2]1([H:13])[C:3]([H:14])([H:15])[N:4]...</td>\n",
+              "      <td>2</td>\n",
+              "      <td>17\\n\\nC 1.687648 -1.481461 0.769379\\nC 1.14635...</td>\n",
+              "      <td>[69.0965, 133.1139, 185.0048, 247.5052, 269.23...</td>\n",
+              "      <td>-434.321489</td>\n",
+              "      <td>-434.224944</td>\n",
+              "      <td>Wilhoit(Cp0=(33.2579,'J/(mol*K)'), CpInf=(407....</td>\n",
+              "      <td>Wilhoit(Cp0=(33.2579,'J/(mol*K)'), CpInf=(407....</td>\n",
+              "      <td>89171.888145</td>\n",
+              "      <td>92902.845218</td>\n",
+              "      <td>384.472728</td>\n",
+              "      <td>384.472728</td>\n",
+              "      <td>138.524841</td>\n",
+              "      <td>138.524841</td>\n",
+              "      <td>175.864528</td>\n",
+              "      <td>175.864528</td>\n",
+              "      <td>208.654500</td>\n",
+              "      <td>208.654500</td>\n",
+              "      <td>236.432193</td>\n",
+              "      <td>236.432193</td>\n",
+              "      <td>278.945081</td>\n",
+              "      <td>278.945081</td>\n",
+              "      <td>308.548112</td>\n",
+              "      <td>308.548112</td>\n",
+              "      <td>350.979140</td>\n",
+              "      <td>350.979140</td>\n",
+              "      <td>-25458.655613</td>\n",
+              "      <td>-21727.698541</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>7667c6f680d9065479d515666e4c3246f65704e4926140...</td>\n",
+              "      <td>[C:1]([C:2]1([H:13])[C:3]([H:14])([H:15])[O:4]...</td>\n",
+              "      <td>2</td>\n",
+              "      <td>21\\n\\nC -2.800669 0.461226 0.774726\\nC -1.7902...</td>\n",
+              "      <td>[40.2091, 100.6031, 169.247, 232.8355, 250.021...</td>\n",
+              "      <td>-403.429122</td>\n",
+              "      <td>-403.298238</td>\n",
+              "      <td>Wilhoit(Cp0=(33.2579,'J/(mol*K)'), CpInf=(507....</td>\n",
+              "      <td>Wilhoit(Cp0=(33.2579,'J/(mol*K)'), CpInf=(507....</td>\n",
+              "      <td>102076.181436</td>\n",
+              "      <td>104632.984293</td>\n",
+              "      <td>397.355792</td>\n",
+              "      <td>397.355792</td>\n",
+              "      <td>153.423259</td>\n",
+              "      <td>153.423259</td>\n",
+              "      <td>200.307331</td>\n",
+              "      <td>200.307331</td>\n",
+              "      <td>241.584659</td>\n",
+              "      <td>241.584659</td>\n",
+              "      <td>276.984827</td>\n",
+              "      <td>276.984827</td>\n",
+              "      <td>332.331738</td>\n",
+              "      <td>332.331738</td>\n",
+              "      <td>371.824840</td>\n",
+              "      <td>371.824840</td>\n",
+              "      <td>429.622128</td>\n",
+              "      <td>429.622128</td>\n",
+              "      <td>-16395.447972</td>\n",
+              "      <td>-13838.645116</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "                 species_dft_log_source_utf_8_sha512  \\\n",
+              "0  42d67c486eb53d22486a5d1da768e644bf644469198894...   \n",
+              "1  7667c6f680d9065479d515666e4c3246f65704e4926140...   \n",
+              "\n",
+              "                                                asmi  multiplicity  \\\n",
+              "0  [C:1]([C:2]1([H:13])[C:3]([H:14])([H:15])[N:4]...             2   \n",
+              "1  [C:1]([C:2]1([H:13])[C:3]([H:14])([H:15])[O:4]...             2   \n",
+              "\n",
+              "                                         std_xyz_str  \\\n",
+              "0  17\\n\\nC 1.687648 -1.481461 0.769379\\nC 1.14635...   \n",
+              "1  21\\n\\nC -2.800669 0.461226 0.774726\\nC -1.7902...   \n",
+              "\n",
+              "                             species_dft_frequencies  \\\n",
+              "0  [69.0965, 133.1139, 185.0048, 247.5052, 269.23...   \n",
+              "1  [40.2091, 100.6031, 169.247, 232.8355, 250.021...   \n",
+              "\n",
+              "   species_dft_hartreefock_energy_hartree  species_dlpno_sp_hartree  \\\n",
+              "0                             -434.321489               -434.224944   \n",
+              "1                             -403.429122               -403.298238   \n",
+              "\n",
+              "                                            p_thermo  \\\n",
+              "0  Wilhoit(Cp0=(33.2579,'J/(mol*K)'), CpInf=(407....   \n",
+              "1  Wilhoit(Cp0=(33.2579,'J/(mol*K)'), CpInf=(507....   \n",
+              "\n",
+              "                                            m_thermo         p_H298  \\\n",
+              "0  Wilhoit(Cp0=(33.2579,'J/(mol*K)'), CpInf=(407....   89171.888145   \n",
+              "1  Wilhoit(Cp0=(33.2579,'J/(mol*K)'), CpInf=(507....  102076.181436   \n",
+              "\n",
+              "          m_H298      p_S298      m_S298     p_Cp300     m_Cp300     p_Cp400  \\\n",
+              "0   92902.845218  384.472728  384.472728  138.524841  138.524841  175.864528   \n",
+              "1  104632.984293  397.355792  397.355792  153.423259  153.423259  200.307331   \n",
+              "\n",
+              "      m_Cp400     p_Cp500     m_Cp500     p_Cp600     m_Cp600     p_Cp800  \\\n",
+              "0  175.864528  208.654500  208.654500  236.432193  236.432193  278.945081   \n",
+              "1  200.307331  241.584659  241.584659  276.984827  276.984827  332.331738   \n",
+              "\n",
+              "      m_Cp800    p_Cp1000    m_Cp1000    p_Cp1500    m_Cp1500        p_G298  \\\n",
+              "0  278.945081  308.548112  308.548112  350.979140  350.979140 -25458.655613   \n",
+              "1  332.331738  371.824840  371.824840  429.622128  429.622128 -16395.447972   \n",
+              "\n",
+              "         m_G298  \n",
+              "0 -21727.698541  \n",
+              "1 -13838.645116  "
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Contains 339428 rows\n"
+          ]
+        }
+      ],
+      "source": [
+        "thermo_data = pd.read_csv(\n",
+        "    PAPER_DIR\n",
+        "    / \"section_3_2_1_thermo\"\n",
+        "    / \"quantum_green_species_data_24august14_dft_opted_dlpno_sp_thermos.csv\"\n",
+        ")\n",
+        "for bac in [\"p\", \"m\"]:\n",
+        "    thermo_data[f\"{bac}_G298\"] = (\n",
+        "        thermo_data[f\"{bac}_H298\"] - 298.15 * thermo_data[f\"{bac}_S298\"]\n",
+        "    )\n",
+        "head(thermo_data)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 6,
+      "id": "7f49b3c8",
       "metadata": {},
       "outputs": [
         {
           "data": {
             "application/vnd.jupyter.widget-view+json": {
-              "model_id": "b258e95324ad4506ac40f65988f19396",
+              "model_id": "73f6adf1c3b7402ea8c646c416642636",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Pandas Apply:   0%|          | 0/339428 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "d47e30c1439d484fbc7baaba7d43d283",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Pandas Apply:   0%|          | 0/166166 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "733c62329b9245539de7dc6c69abf619",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Pandas Apply:   0%|          | 0/166166 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "a4633b057487401baffc83c622b517df",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Pandas Apply:   0%|          | 0/166166 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "45e4fa5162d74325aacf316cc55f0c2a",
               "version_major": 2,
               "version_minor": 0
             },
@@ -449,13 +720,41 @@
         }
       ],
       "source": [
-        "rate_data[\"clean_rxn_smi\"] = rate_data[\"rxn_smi\"].swifter.apply(clean_rxn_smi)"
+        "thermo_canonical_smiles = thermo_data[\"asmi\"].swifter.apply(canonical_smiles)\n",
+        "mapping = {\n",
+        "    prop: dict(zip(thermo_canonical_smiles, thermo_data[prop]))\n",
+        "    for prop in [\"m_H298\", \"m_G298\", \"p_H298\", \"p_G298\"]\n",
+        "}\n",
+        "component_smiles = {\n",
+        "    component: rate_data[f\"{component}smi\"].swifter.apply(canonical_smiles)\n",
+        "    for component in [\"r1\", \"r2\", \"p1\", \"p2\"]\n",
+        "}\n",
+        "delta_rxn_298 = {\n",
+        "    prop: (\n",
+        "        component_smiles[\"p1\"].apply(mapping[prop].get)\n",
+        "        + component_smiles[\"p2\"].apply(mapping[prop].get)\n",
+        "        - component_smiles[\"r1\"].apply(mapping[prop].get)\n",
+        "        - component_smiles[\"r2\"].apply(mapping[prop].get)\n",
+        "    )\n",
+        "    for prop in [\"m_H298\", \"m_G298\", \"p_H298\", \"p_G298\"]\n",
+        "}"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 6,
-      "id": "64722744",
+      "execution_count": 7,
+      "id": "f83185d5",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "P2M = delta_rxn_298[\"m_H298\"] - delta_rxn_298[\"p_H298\"]\n",
+        "assert np.isclose(delta_rxn_298[\"m_G298\"] - delta_rxn_298[\"p_G298\"], P2M).all()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 8,
+      "id": "31b54917",
       "metadata": {},
       "outputs": [
         {
@@ -735,16 +1034,65 @@
         }
       ],
       "source": [
-        "zpe_data = pd.read_pickle(PAPER_DIR / \"ts_key_characteristics_july31a.pkl\")\n",
-        "head(zpe_data)"
+        "ts_key_char = pd.read_pickle(\n",
+        "    PAPER_DIR / \"section_3_2_3_rate\" / \"ts_key_characteristics_july31a.pkl\"\n",
+        ")\n",
+        "head(ts_key_char)"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 7,
+      "execution_count": 9,
+      "id": "0b071a57",
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "2bfb3cff59be447a905d60e5e8bd642c",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Pandas Apply:   0%|          | 0/167237 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "ts_clean_smiles = ts_key_char[\"rxn_smi\"].swifter.apply(clean_rxn_smi)\n",
+        "ts_mappings = {\n",
+        "    \"barrier\": dict(\n",
+        "        zip(ts_clean_smiles, ts_key_char[\"fwd_barrier_dlpno_sp_dft_zpe_scaled_kcal\"])\n",
+        "    ),\n",
+        "    \"Hrxn\": dict(\n",
+        "        zip(ts_clean_smiles, ts_key_char[\"fwd_Hrxn_dlpno_sp_dft_zpe_scaled_kcal\"])\n",
+        "    ),\n",
+        "}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 10,
       "id": "d15f61d6",
       "metadata": {},
       "outputs": [
+        {
+          "data": {
+            "application/vnd.jupyter.widget-view+json": {
+              "model_id": "7206c8b32eaf4c619e256fc9eeefabcb",
+              "version_major": 2,
+              "version_minor": 0
+            },
+            "text/plain": [
+              "Pandas Apply:   0%|          | 0/166166 [00:00<?, ?it/s]"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
         {
           "data": {
             "text/html": [
@@ -773,7 +1121,10 @@
               "      <th>A_high</th>\n",
               "      <th>Ea_high</th>\n",
               "      <th>barrier</th>\n",
-              "      <th>Hrxn</th>\n",
+              "      <th>deltaHrxn</th>\n",
+              "      <th>deltaHrxn298</th>\n",
+              "      <th>deltaGrxn298</th>\n",
+              "      <th>P2M</th>\n",
               "    </tr>\n",
               "  </thead>\n",
               "  <tbody>\n",
@@ -787,6 +1138,9 @@
               "      <td>23.611069</td>\n",
               "      <td>15.910219</td>\n",
               "      <td>7.702692</td>\n",
+              "      <td>8.072324</td>\n",
+              "      <td>6.348599</td>\n",
+              "      <td>0.587593</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <th>1</th>\n",
@@ -796,8 +1150,11 @@
               "      <td>16.284605</td>\n",
               "      <td>6.078441e+06</td>\n",
               "      <td>24.558463</td>\n",
-              "      <td>17.0254</td>\n",
+              "      <td>17.025400</td>\n",
               "      <td>7.738855</td>\n",
+              "      <td>7.786894</td>\n",
+              "      <td>7.714869</td>\n",
+              "      <td>0.652457</td>\n",
               "    </tr>\n",
               "  </tbody>\n",
               "</table>\n",
@@ -808,9 +1165,13 @@
               "0    [O]O.CC(CC=O)C1CC1>>C[C](CC=O)C1CC1.OO  1.961906e-07  19300.901420   \n",
               "1  [O]O.COCC(C)OC1CC1>>[CH2]OCC(C)OC1CC1.OO  1.102303e-07  44694.157891   \n",
               "\n",
-              "      Ea_low        A_high    Ea_high    barrier      Hrxn  \n",
-              "0  15.420109  2.461429e+06  23.611069  15.910219  7.702692  \n",
-              "1  16.284605  6.078441e+06  24.558463    17.0254  7.738855  "
+              "      Ea_low        A_high    Ea_high    barrier  deltaHrxn  deltaHrxn298  \\\n",
+              "0  15.420109  2.461429e+06  23.611069  15.910219   7.702692      8.072324   \n",
+              "1  16.284605  6.078441e+06  24.558463  17.025400   7.738855      7.786894   \n",
+              "\n",
+              "   deltaGrxn298       P2M  \n",
+              "0      6.348599  0.587593  \n",
+              "1      7.714869  0.652457  "
             ]
           },
           "metadata": {},
@@ -825,20 +1186,21 @@
         }
       ],
       "source": [
+        "rate_clean_rxn_smiles = rate_data[\"rxn_smi\"].swifter.apply(clean_rxn_smi)\n",
+        "\n",
         "kinetics_df = pd.DataFrame(\n",
         "    {\n",
-        "        \"rxn_smi\": rate_data[\"clean_rxn_smi\"],\n",
+        "        \"rxn_smi\": rate_clean_rxn_smiles,\n",
         "        \"k_298\": rate_data[\"k_298\"],\n",
         "        \"A_low\": rate_data[\"low_A\"],\n",
         "        \"Ea_low\": rate_data[\"low_Ea\"] / 4184,\n",
         "        \"A_high\": rate_data[\"high_A\"],\n",
         "        \"Ea_high\": rate_data[\"high_Ea\"] / 4184,\n",
-        "        \"barrier\": rate_data[\"rxn_smi\"].map(\n",
-        "            zpe_data.set_index(\"rxn_smi\")[\"fwd_barrier_dlpno_sp_dft_zpe_scaled_kcal\"]\n",
-        "        ),\n",
-        "        \"Hrxn\": rate_data[\"rxn_smi\"].map(\n",
-        "            zpe_data.set_index(\"rxn_smi\")[\"fwd_Hrxn_dlpno_sp_dft_zpe_scaled_kcal\"]\n",
-        "        ),\n",
+        "        \"barrier\": rate_clean_rxn_smiles.map(ts_mappings[\"barrier\"]),\n",
+        "        \"deltaHrxn\": rate_clean_rxn_smiles.map(ts_mappings[\"Hrxn\"]),\n",
+        "        \"deltaHrxn298\": delta_rxn_298[\"p_H298\"] / 4184,\n",
+        "        \"deltaGrxn298\": delta_rxn_298[\"p_G298\"] / 4184,\n",
+        "        \"P2M\": P2M / 4184,\n",
         "    }\n",
         ")\n",
         "head(kinetics_df)"
@@ -854,7 +1216,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 8,
+      "execution_count": 11,
       "id": "cec2bff0",
       "metadata": {},
       "outputs": [
@@ -886,7 +1248,10 @@
               "      <th>A_high</th>\n",
               "      <th>Ea_high</th>\n",
               "      <th>barrier</th>\n",
-              "      <th>Hrxn</th>\n",
+              "      <th>deltaHrxn</th>\n",
+              "      <th>deltaHrxn298</th>\n",
+              "      <th>deltaGrxn298</th>\n",
+              "      <th>P2M</th>\n",
               "    </tr>\n",
               "  </thead>\n",
               "  <tbody>\n",
@@ -898,8 +1263,11 @@
               "      <td>17.604535</td>\n",
               "      <td>9.092064e+06</td>\n",
               "      <td>25.521593</td>\n",
-              "      <td>17.675881</td>\n",
+              "      <td>18.049820</td>\n",
               "      <td>11.564115</td>\n",
+              "      <td>12.010234</td>\n",
+              "      <td>10.572140</td>\n",
+              "      <td>0.636948</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <th>50982</th>\n",
@@ -909,8 +1277,11 @@
               "      <td>17.901227</td>\n",
               "      <td>9.076999e+06</td>\n",
               "      <td>25.890575</td>\n",
-              "      <td>18.04982</td>\n",
+              "      <td>18.049820</td>\n",
               "      <td>11.564115</td>\n",
+              "      <td>12.010234</td>\n",
+              "      <td>10.572140</td>\n",
+              "      <td>0.636948</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <th>1736</th>\n",
@@ -920,8 +1291,11 @@
               "      <td>10.954568</td>\n",
               "      <td>2.641035e+06</td>\n",
               "      <td>18.847794</td>\n",
-              "      <td>11.939024</td>\n",
+              "      <td>11.701590</td>\n",
               "      <td>4.886974</td>\n",
+              "      <td>5.022356</td>\n",
+              "      <td>4.285975</td>\n",
+              "      <td>0.620976</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <th>28048</th>\n",
@@ -931,8 +1305,11 @@
               "      <td>10.772518</td>\n",
               "      <td>2.644290e+06</td>\n",
               "      <td>18.612342</td>\n",
-              "      <td>11.70159</td>\n",
+              "      <td>11.701590</td>\n",
               "      <td>4.886974</td>\n",
+              "      <td>5.022356</td>\n",
+              "      <td>4.285975</td>\n",
+              "      <td>0.620976</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <th>26312</th>\n",
@@ -942,8 +1319,11 @@
               "      <td>12.247945</td>\n",
               "      <td>3.577528e+06</td>\n",
               "      <td>20.469567</td>\n",
-              "      <td>13.422543</td>\n",
+              "      <td>13.886253</td>\n",
               "      <td>4.863133</td>\n",
+              "      <td>4.983081</td>\n",
+              "      <td>4.303859</td>\n",
+              "      <td>0.619167</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <th>45920</th>\n",
@@ -955,6 +1335,9 @@
               "      <td>21.473775</td>\n",
               "      <td>13.886253</td>\n",
               "      <td>4.863133</td>\n",
+              "      <td>4.983081</td>\n",
+              "      <td>4.303859</td>\n",
+              "      <td>0.619167</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <th>99824</th>\n",
@@ -964,8 +1347,11 @@
               "      <td>23.370464</td>\n",
               "      <td>7.019250e+07</td>\n",
               "      <td>31.356097</td>\n",
-              "      <td>23.360555</td>\n",
+              "      <td>23.482685</td>\n",
               "      <td>14.489843</td>\n",
+              "      <td>14.865208</td>\n",
+              "      <td>14.215183</td>\n",
+              "      <td>0.360530</td>\n",
               "    </tr>\n",
               "    <tr>\n",
               "      <th>101950</th>\n",
@@ -977,6 +1363,9 @@
               "      <td>31.477803</td>\n",
               "      <td>23.482685</td>\n",
               "      <td>14.489843</td>\n",
+              "      <td>14.865208</td>\n",
+              "      <td>14.215183</td>\n",
+              "      <td>0.360530</td>\n",
               "    </tr>\n",
               "  </tbody>\n",
               "</table>\n",
@@ -994,53 +1383,53 @@
               "101950  [O]O.c1cc(C2CC2)n[nH]1>>C1=CC(C2CC2)=N[N]1.OO  7.771742e-12   \n",
               "\n",
               "                A_low     Ea_low        A_high    Ea_high    barrier  \\\n",
-              "23746    88431.113184  17.604535  9.092064e+06  25.521593  17.675881   \n",
-              "50982    83832.751812  17.901227  9.076999e+06  25.890575   18.04982   \n",
-              "1736     25467.490169  10.954568  2.641035e+06  18.847794  11.939024   \n",
-              "28048    26490.293900  10.772518  2.644290e+06  18.612342   11.70159   \n",
-              "26312    27216.175834  12.247945  3.577528e+06  20.469567  13.422543   \n",
+              "23746    88431.113184  17.604535  9.092064e+06  25.521593  18.049820   \n",
+              "50982    83832.751812  17.901227  9.076999e+06  25.890575  18.049820   \n",
+              "1736     25467.490169  10.954568  2.641035e+06  18.847794  11.701590   \n",
+              "28048    26490.293900  10.772518  2.644290e+06  18.612342  11.701590   \n",
+              "26312    27216.175834  12.247945  3.577528e+06  20.469567  13.886253   \n",
               "45920   195480.415751  13.392528  2.357858e+07  21.473775  13.886253   \n",
-              "99824   635512.487498  23.370464  7.019250e+07  31.356097  23.360555   \n",
+              "99824   635512.487498  23.370464  7.019250e+07  31.356097  23.482685   \n",
               "101950  628833.967265  23.478245  7.017883e+07  31.477803  23.482685   \n",
               "\n",
-              "             Hrxn  \n",
-              "23746   11.564115  \n",
-              "50982   11.564115  \n",
-              "1736     4.886974  \n",
-              "28048    4.886974  \n",
-              "26312    4.863133  \n",
-              "45920    4.863133  \n",
-              "99824   14.489843  \n",
-              "101950  14.489843  "
+              "        deltaHrxn  deltaHrxn298  deltaGrxn298       P2M  \n",
+              "23746   11.564115     12.010234     10.572140  0.636948  \n",
+              "50982   11.564115     12.010234     10.572140  0.636948  \n",
+              "1736     4.886974      5.022356      4.285975  0.620976  \n",
+              "28048    4.886974      5.022356      4.285975  0.620976  \n",
+              "26312    4.863133      4.983081      4.303859  0.619167  \n",
+              "45920    4.863133      4.983081      4.303859  0.619167  \n",
+              "99824   14.489843     14.865208     14.215183  0.360530  \n",
+              "101950  14.489843     14.865208     14.215183  0.360530  "
             ]
           },
-          "execution_count": 8,
+          "execution_count": 11,
           "metadata": {},
           "output_type": "execute_result"
         }
       ],
       "source": [
-        "kinetics_df[kinetics_df[\"rxn_smi\"].duplicated(keep=False)].sort_values(by=\"rxn_smi\")"
+        "kinetics_df[rate_clean_rxn_smiles.duplicated(keep=False)].sort_values(by=\"rxn_smi\")"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": 12,
       "id": "7402d0c2",
       "metadata": {},
       "outputs": [],
       "source": [
-        "kinetics_df_no_duplicates = kinetics_df.drop_duplicates(subset=\"rxn_smi\", keep=False)"
+        "kinetics_df_dedup = kinetics_df.drop_duplicates(subset=\"rxn_smi\", keep=False)"
       ]
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 13,
       "id": "c02c1c6b",
       "metadata": {},
       "outputs": [],
       "source": [
-        "kinetics_df_no_duplicates.to_csv(\n",
+        "kinetics_df_dedup.to_csv(\n",
         "    DATABASE_DIR / \"quantumpioneer_kinetics_dataset.csv\", index=False\n",
         ")"
       ]


### PR DESCRIPTION
## Summary

Extends the kinetics dataset with three new thermodynamic columns derived from BAC-corrected quantum chemistry calculations, enabling equilibrium constant analysis directly from the dataset.

### New columns in `quantumpioneer_kinetics_dataset.csv`

| Column | Units | Description |
|---|---|---|
| `deltaHrxn298` | kcal/mol | Forward reaction enthalpy at 298 K (Petersson BACs) |
| `deltaGrxn298` | kcal/mol | Forward reaction Gibbs energy at 298 K (Petersson BACs) |
| `P2M` | kcal/mol | Petersson-to-Melius energy difference at 298 K |

Adding `P2M` to `deltaHrxn298` or `deltaGrxn298` yields the corresponding Melius-type BAC-corrected values.

### Changes

- **`data/kinetics/README.md`** — documents the three new columns and explains the Petersson/Melius BAC relationship
- **`data/thermo/README.md`** — renames `DHPM` → `P2M` for consistency with the kinetics dataset
- **`scripts/kinetics/collect_kinetic_data.ipynb`** — computes `deltaHrxn298`, `deltaGrxn298`, and `P2M` from species thermo data; fixes `canonical_smiles` to handle atom-map renumbering before canonicalization; updates variable names for clarity

## Test plan

- [x] Re-run `collect_kinetic_data.ipynb` end-to-end and verify the output CSV contains all new columns with physically reasonable values
- [x] Confirm duplicated-SMILES rows are still correctly identified and dropped